### PR TITLE
Configurable hitcount cache lifetime

### DIFF
--- a/popularity/tasks.py
+++ b/popularity/tasks.py
@@ -71,6 +71,10 @@ def update_hitcount(session_key, ip_address, user_agent, username,
 
 class HitCountJob(Job):
 
+    def __init__(self, *args, **kwargs):
+        self.lifetime = getattr(settings, 'HITCOUNT_REFRESH_INTERVAL', 600)
+        return super(HitCountJob, self).__init__(*args, **kwargs)
+
     def fetch(self, app_label, model, object_id):
         ctype = ContentType.objects.get(app_label=app_label, model=model)
         try:


### PR DESCRIPTION
hitcount cache lifetime respect "HITCOUNT_REFRESH_INTERVAL" in settings

Not sure hot to write a test case as HitCountJob.get() is async and it seems that update_hitcount not called until tearDown.
